### PR TITLE
Set the Ruby version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@
 
 source "https://rubygems.org"
 
+ruby "3.3.2"
+
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.2.2"
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -364,5 +364,8 @@ DEPENDENCIES
   tzinfo-data
   web-console
 
+RUBY VERSION
+   ruby 3.3.2p78
+
 BUNDLED WITH
    2.6.0


### PR DESCRIPTION
## Problem / Motivation

When we realize the first deploy to Heroku we receive this error:

```
Total 199 (delta 39), reused 0 (delta 0), pack-reused 0 (from 0)
remote: Resolving deltas: 100% (39/39), done.
remote: Updated 110 paths from 6f089d2
remote: Compressing source files... done.
remote: Building source:
remote: 
remote: -----> Building on the Heroku-24 stack
remote: -----> Determining which buildpack to use for this app
remote: -----> Ruby app detected
remote: -----> Installing bundler 2.5.6
remote: -----> Removing BUNDLED WITH version in the Gemfile.lock
remote: -----> Compiling Ruby/Rails
remote: 
remote: ###### WARNING:
remote: 
remote:        No ruby version specified in the Gemfile.lock
remote:        
remote:        We could not determine the version of Ruby from your Gemfile.lock.
remote:        
remote:          $ bundle platform --ruby
remote:          No ruby version specified
remote:        
remote:          $ bundle -v
remote:          Bundler version 2.5.6
remote:        
remote:        
remote:        Ensure the above command outputs the version of Ruby you expect. If you have a ruby version specified in your Gemfile, you can update the Gemfile.lock by running the following command:
remote:        
remote:          $ bundle update --ruby
remote:        
remote:        Make sure you commit the results to git before attempting to deploy again:
remote:        
remote:          $ git add Gemfile.lock
remote:          $ git commit -m "update ruby version"
remote: 
remote: -----> Using Ruby version: ruby-3.1.6
remote: -----> Installing dependencies using bundler 2.5.6
remote:        Running: BUNDLE_WITHOUT='development:test' BUNDLE_PATH=vendor/bundle BUNDLE_BIN=vendor/bundle/bin BUNDLE_DEPLOYMENT=1 bundle install -j4
remote:        Fetching gem metadata from https://rubygems.org/.........
remote:        zeitwerk-2.7.1 requires ruby version >= 3.2, which is incompatible with the
remote:        current version, 3.1.6
remote:        Bundler Output: Fetching gem metadata from https://rubygems.org/.........
remote:        zeitwerk-2.7.1 requires ruby version >= 3.2, which is incompatible with the
remote:        current version, 3.1.6
remote: 
remote:  !
remote:  !     Failed to install gems via Bundler.
remote:  !
remote:  !     Push rejected, failed to compile Ruby app.
remote: 
remote:  !     Push failed
remote: Verifying deploy...
remote: 
remote: !	Push rejected to todo-list-app.
remote: 
To https://git.heroku.com/todo-list-app.git
 ! [remote rejected] main -> main (pre-receive hook declined)
error: failed to push some refs to 'https://git.heroku.com/todo-list-app.git'
```
## Solution

Specify the Ruby version in `Gemfile`.

## Tasks

* [x] Specify the Ruby version in `Gemfile`.

## Tickets

* We don't have tickets.

## Changelog

No changes since this PR has been ready for review.

## Test Plan

The test plan consists of running the deploy to Heroku again.