### PR TITLE
Feature/implement use cases

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,8 @@ group :development, :test do
   # Faker gem to generate fake data for testing and development
   gem "faker", "~> 3.5", ">= 3.5.1"
 
+  gem 'mocha', '~> 2.7', '>= 2.7.1'
+
   # Debugging tool for the Rails console
   gem "pry-rails", "~> 0.3.11"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,6 +149,8 @@ GEM
     method_source (1.1.0)
     mini_mime (1.1.5)
     minitest (5.25.4)
+    mocha (2.7.1)
+      ruby2_keywords (>= 0.0.5)
     msgpack (1.7.5)
     net-imap (0.5.2)
       date
@@ -270,6 +272,7 @@ GEM
       rubocop-performance
       rubocop-rails
     ruby-progressbar (1.13.0)
+    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     securerandom (0.4.1)
     selenium-webdriver (4.27.0)
@@ -343,6 +346,7 @@ DEPENDENCIES
   faker (~> 3.5, >= 3.5.1)
   importmap-rails
   jbuilder
+  mocha (~> 2.7, >= 2.7.1)
   pg (~> 1.1)
   pry-rails (~> 0.3.11)
   puma (>= 5.0)

--- a/app/use_cases/result_error.rb
+++ b/app/use_cases/result_error.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class ResultError
+  attr_reader :status
+
+  def initialize(errors = {}, status = :error)
+    @errors = errors
+    @status = status
+  end
+
+  def attributes
+    errors
+  end
+
+  def successful?
+    false
+  end
+
+  private
+
+  attr_reader :errors
+end

--- a/app/use_cases/result_success.rb
+++ b/app/use_cases/result_success.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class ResultSuccess
+  attr_reader :attributes, :status
+
+  def initialize(attributes = {}, status = :success)
+    @attributes = attributes
+    @status = status
+  end
+
+  def successful?
+    true
+  end
+end

--- a/app/use_cases/todo/create/use_case.rb
+++ b/app/use_cases/todo/create/use_case.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class Todo::Create::UseCase
+  def self.call(user: nil, params: nil)
+    new(user: user, params: params).call
+  end
+
+  def initialize(user:, params:)
+    @user = user
+    @params = params
+  end
+
+  def call
+    validation = Todo::Create::Validation.new(user: user, params: params)
+
+    if validation.valid?
+      todo = Todo.create(params.merge(user: user))
+
+      ResultSuccess.new
+    else
+      ResultError.new(validation.errors)
+    end
+  end
+
+  private
+
+  attr_reader :user, :params
+end

--- a/app/use_cases/todo/create/validation.rb
+++ b/app/use_cases/todo/create/validation.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class Todo::Create::Validation
+  include ActiveModel::Validations
+  include ActiveModel::Model
+
+  attr_accessor :user, :params
+
+  validates :user, presence: true
+  validates :params, presence: true
+
+  validate :validate_title
+  validate :validate_status
+
+  private
+
+  def validate_title
+    if params[:title].blank?
+      errors.add(:base, 'Title cannot be blank!')
+    elsif params[:title].size > 40
+      errors.add(:base, 'Title is too long! Maximum is 40 characters.')
+    end
+  end
+
+  def validate_status
+    errors.add(:base, 'The status cannot be "completed" when creating a Todo!') if params[:status] == 'complete'
+  end
+end

--- a/app/use_cases/todo/destroy/use_case.rb
+++ b/app/use_cases/todo/destroy/use_case.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Todo::Destroy::UseCase
+  def self.call(user: nil, params: nil)
+    new(user: user, params: params).call
+  end
+
+  def initialize(user:, params:)
+    @user = user
+    @params = params
+  end
+
+  def call
+    todo = Todo.find_by(id: params[:id])
+
+    validation = Todo::Destroy::Validation.new(user: user, todo: todo)
+
+    if validation.valid?
+      todo.destroy
+
+      ResultSuccess.new
+    else
+      ResultError.new(validation.errors)
+    end
+  end
+
+  private
+
+  attr_reader :user, :params
+end

--- a/app/use_cases/todo/destroy/validation.rb
+++ b/app/use_cases/todo/destroy/validation.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Todo::Destroy::Validation
+  include ActiveModel::Validations
+  include ActiveModel::Model
+
+  attr_accessor :user, :todo
+
+  validates :user, presence: true
+  validates :todo, presence: true
+
+  validate :validate_user_ownership
+
+  private
+
+  def validate_user_ownership
+    errors.add(:base, 'You are not authorized to delete this Todo!') if todo.user != user
+  end
+end

--- a/app/use_cases/todo/update/use_case.rb
+++ b/app/use_cases/todo/update/use_case.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Todo::Update::UseCase
+  def self.call(user: nil, params: nil)
+    new(user: user, params: params).call
+  end
+
+  def initialize(user:, params:)
+    @user = user
+    @params = params
+  end
+
+  def call
+    todo = Todo.find_by(id: params[:id])
+
+    validation = Todo::Update::Validation.new(user: user, params: params)
+
+    if validation.valid?
+      todo.update(params.merge(user: user))
+
+      ResultSuccess.new
+    else
+      ResultError.new(validation.errors)
+    end
+  end
+
+  private
+
+  attr_reader :user, :params
+end

--- a/app/use_cases/todo/update/validation.rb
+++ b/app/use_cases/todo/update/validation.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class Todo::Update::Validation
+  include ActiveModel::Validations
+  include ActiveModel::Model
+
+  attr_accessor :user, :params
+
+  validates :user, presence: true
+  validates :params, presence: true
+
+  validate :validate_title, if: -> { params.key?(:title) }
+  validate :validate_status, if: -> { params.key?(:status) }
+
+  private
+
+  def validate_title
+    if params[:title].blank?
+      errors.add(:base, 'Title cannot be blank!')
+    elsif params[:title].size > 40
+      errors.add(:base, 'Title is too long! Maximum is 40 characters.')
+    end
+  end
+
+  def validate_status
+    errors.add(:base, 'Status is invalid!') if Todo.statuses.keys.exclude?(params[:status])
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,10 +4,13 @@ ENV["RAILS_ENV"] ||= "test"
 
 require_relative "../config/environment"
 require "rails/test_help"
-require 'faker'
-require 'simplecov'
-require 'shoulda/matchers'
-require 'shoulda/context'
+require "faker"
+require "simplecov"
+require "shoulda/matchers"
+require "shoulda/context"
+require "minitest/autorun"
+require "mocha/minitest"
+require "ostruct"
 
 SimpleCov.start
 

--- a/test/use_cases/todo/create/use_case_test.rb
+++ b/test/use_cases/todo/create/use_case_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Todo::Create::UseCaseTest < ActiveSupport::TestCase
+  setup do
+    @user = create(:user)
+  end
+
+  context "#call method" do
+    should "return success when Todo is valid" do
+      Todo::Create::Validation.any_instance.stubs(:valid?).returns(true)
+
+      assert_difference('Todo.count', 1) do
+        @result = Todo::Create::UseCase.call(user: @user, params: { title: 'Todo title' })
+      end
+
+      assert_instance_of ResultSuccess, @result
+      assert_predicate(@result, :successful?)
+    end
+
+    should "return error when Todo is invalid" do
+      Todo::Create::Validation.any_instance.stubs(:valid?).returns(false)
+
+      assert_no_difference('Todo.count') do
+        @result = Todo::Create::UseCase.call(user: @user, params: { title: '' })
+      end
+
+      assert_instance_of ResultError, @result
+      assert_not_predicate(@result, :successful?)
+    end
+  end
+end

--- a/test/use_cases/todo/create/validation_test.rb
+++ b/test/use_cases/todo/create/validation_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Todo::Create::ValidationTest < ActiveSupport::TestCase
+  setup do
+    @user = create(:user)
+  end
+
+  context "#valid?" do
+    should "return valid when the Todo is valid" do
+      validation = Todo::Create::Validation.new(user: @user, params: { title: 'Todo title' })
+
+      assert_predicate validation, :valid?
+    end
+  end
+
+  context "#invalid?" do
+    context "#validate_title validation" do
+      should "return invalid when the title is blank" do
+        validation = Todo::Create::Validation.new(user: @user, params: { title: '' })
+
+        assert_predicate validation, :invalid?
+        assert_equal 'Title cannot be blank!', validation.errors[:base].first
+      end
+
+      should "return invalid when the title is too long" do
+        validation = Todo::Create::Validation.new(user: @user, params: { title: Faker::Lorem.characters(number: 41) })
+
+        assert_predicate validation, :invalid?
+        assert_equal 'Title is too long! Maximum is 40 characters.', validation.errors[:base].first
+      end
+    end
+
+    context "#validate_status validation" do
+      should "return invalid when trying to create a Todo with status 'complete'" do
+        validation = Todo::Create::Validation.new(user: @user, params: { title: 'Todo title', status: 'complete' })
+
+        assert_predicate validation, :invalid?
+        assert_equal 'The status cannot be "completed" when creating a Todo!', validation.errors[:base].first
+      end
+    end
+  end
+end

--- a/test/use_cases/todo/destroy/use_case_test.rb
+++ b/test/use_cases/todo/destroy/use_case_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Todo::Destroy::UseCaseTest < ActiveSupport::TestCase
+  setup do
+    @user = create(:user)
+    @todo = create(:todo, user: @user)
+  end
+
+  context "#call method" do
+    should "return success when Todo is valid" do
+      Todo::Destroy::Validation.any_instance.stubs(:valid?).returns(true)
+      
+      assert_difference "Todo.count", -1 do
+        @result = Todo::Destroy::UseCase.call(user: @user, params: { id: @todo.id })
+      end
+
+      assert_instance_of ResultSuccess, @result
+      assert_predicate(@result, :successful?)
+    end
+
+    should "return error when Todo is invalid" do
+      Todo::Destroy::Validation.any_instance.stubs(:valid?).returns(false)
+
+      assert_no_difference "Todo.count" do
+        @result = Todo::Destroy::UseCase.call(user: @user, params: { id: @todo.id })
+      end
+      
+      assert_instance_of ResultError, @result
+      assert_not_predicate(@result, :successful?)
+    end
+  end
+end

--- a/test/use_cases/todo/destroy/validation_test.rb
+++ b/test/use_cases/todo/destroy/validation_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Todo::Destroy::ValidationTest < ActiveSupport::TestCase
+  setup do
+    @user = create(:user)
+    @todo = create(:todo, user: @user)
+  end
+
+  context "#valid?" do
+    should "return valid when the Todo is valid" do
+      validation = Todo::Destroy::Validation.new(user: @user, todo: @todo)
+
+      assert_predicate validation, :valid?
+    end
+  end
+
+  context "#invalid?" do
+    context "#validate_user_ownership validation" do
+      setup do
+        @unauthorized_user = create(:user)
+      end
+
+      should "return invalid when the user is not authorized to delete the Todo" do
+        validation = Todo::Destroy::Validation.new(user: @unauthorized_user, todo: @todo)
+
+        assert_predicate validation, :invalid?
+        assert_equal 'You are not authorized to delete this Todo!', validation.errors[:base].first
+      end
+    end
+  end
+end

--- a/test/use_cases/todo/update/use_case_test.rb
+++ b/test/use_cases/todo/update/use_case_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Todo::Update::UseCaseTest < ActiveSupport::TestCase
+  setup do
+    @user = create(:user)
+    @todo = create(:todo, title: 'Old title', user: @user)
+  end
+
+  context "#call method" do
+    should "return success when Todo is valid" do
+      Todo::Update::Validation.any_instance.stubs(:valid?).returns(true)
+
+      assert_changes '@todo.reload.title' do
+        @result = Todo::Update::UseCase.call(user: @user, params: { id: @todo.id, title: 'New title' })
+      end
+
+      assert_instance_of ResultSuccess, @result
+      assert_predicate(@result, :successful?)
+    end
+
+    should "return error when Todo is invalid" do
+      Todo::Update::Validation.any_instance.stubs(:valid?).returns(false)
+
+      assert_no_changes '@todo.status' do
+        @result = Todo::Update::UseCase.call(user: @user, params: { id: @todo.id, status: 'complete' })
+      end
+      
+      assert_instance_of ResultError, @result
+      assert_not_predicate(@result, :successful?)
+    end
+  end
+end

--- a/test/use_cases/todo/update/validation_test.rb
+++ b/test/use_cases/todo/update/validation_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Todo::Update::ValidationTest < ActiveSupport::TestCase
+  setup do
+    @user = create(:user)
+  end
+
+  context "#valid?" do
+    should "return valid when the Todo is valid" do
+      validation = Todo::Update::Validation.new(user: @user, params: { title: 'Todo title' })
+
+      assert_predicate validation, :valid?
+    end
+  end
+
+  context "#invalid?" do
+    context "#validate_title validation" do
+      should "return invalid when the title is blank" do
+        validation = Todo::Update::Validation.new(user: @user, params: { title: '' })
+
+        assert_predicate validation, :invalid?
+        assert_equal 'Title cannot be blank!', validation.errors[:base].first
+      end
+
+      should "return invalid when the title is too long" do
+        validation = Todo::Update::Validation.new(user: @user, params: { title: Faker::Lorem.characters(number: 41) })
+
+        assert_predicate validation, :invalid?
+        assert_equal 'Title is too long! Maximum is 40 characters.', validation.errors[:base].first
+      end
+    end
+
+    context "#validate_status validation" do
+      should "return invalid when trying to create a Todo with status 'complete'" do
+        validation = Todo::Update::Validation.new(user: @user, params: { title: 'Todo title', status: 'archive' })
+
+        assert_predicate validation, :invalid?
+        assert_equal 'Status is invalid!', validation.errors[:base].first
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem / Motivation

We need to separate the business rules from the controller to make the flow cleaner and easier to maintain.

## Solution

Implement UseCases for creating, updating, and destroying Todos, along with their respective tests to ensure code quality.

## Tasks

* [x] Create UseCases for creating, updating, and destroying Todos;
* [x] Implement the UseCases in the `TodosController`;
* [x] Create and update existing tests to ensure code quality and coverage.

## Tickets

* We don't have tickets.

## Changelog

No changes since this PR has been ready for review.

## Test Plan

The test plan consists of running the tests developed with MiniTest locally, performing a manual verification through `localhost`, and running the tests via the CI/CD pipeline.

```
$ rails t
Finished in 0.861908s, 45.2484 runs/s, 119.5023 assertions/s.
39 runs, 103 assertions, 0 failures, 0 errors, 0 skips
Line Coverage: 99.75% (404 / 405)
```